### PR TITLE
Fix config file call

### DIFF
--- a/Software_&_Example/rc.local
+++ b/Software_&_Example/rc.local
@@ -23,9 +23,8 @@ echo max5802w 0x0F > /sys/class/i2c-adapter/i2c-1/new_device
 
 mount /dev/mmcblk0p1 /media/uSD
 
-
 sleep 20
-cd /var/lib/cloud9/POPS
-/var/lib/cloud9/POPS/popsdt "/media/uSD/POPS_BBB.cfg" &
+cd /var/lib/cloud9/POPS/Software_\&_Example
+/var/lib/cloud9/POPS/popsdt < /media/uSD/POPS_BBB.cfg &
 
 exit 0


### PR DESCRIPTION
Change the rc.local to have the program run as:
popsdt < POPS_BBB.cfg &
This runs the program with the specified config file in the background. 